### PR TITLE
Update README.md to use correct install name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ been warned...
 ## Installation
 
 ```sh
-npm install ajv-formats
+npm install --save ajv-formats-draft2019
 ```
 
 ## Usage


### PR DESCRIPTION
It appears the old package name, `ajv-formats`, has an API different than what is given in the README.