### PR TITLE
Add support for `modbus+tcp` and `mqtt` as URI schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ The string is checked against a regex.
 
 ## Releases
 
+### `v1.5.2`
+
+- Updated `schemes` dependency, adding support for `modbus+tcp` and `mqtt` in URIs.
+
 ### `v1.5.1`
 
 - Fix tests to work with AJV v7+ and how `ajv` is exported, rather than changes

--- a/index.test.js
+++ b/index.test.js
@@ -41,6 +41,10 @@ describe('load types', function () {
     assert.ok(validate('tel:+1-816-555-1212'));
     assert.ok(validate('telnet://192.0.2.16:80/'));
     assert.ok(validate('urn:oasis:names:specification:docbook:dtd:xml:4.1.2'));
+
+    // https://github.com/luzlab/ajv-formats-draft2019/issues/11
+    assert.ok(validate('modbus+tcp://1.2.3.4/path'));
+    assert.ok(validate('mqtt://1.2.3.4/path'));
   });
 
   it('reject invalid IRIs', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.1.1",
-        "schemes": "^1.3.0",
+        "schemes": "^1.4.0",
         "smtp-address-parser": "^1.0.3",
         "uri-js": "^4.4.1"
       },
@@ -923,9 +923,9 @@
       ]
     },
     "node_modules/schemes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/schemes/-/schemes-1.3.0.tgz",
-      "integrity": "sha512-j897hccQkOKrATAnSFfERCv07Wxw5ciXfQCxD0hUWG54nqSWcqv+6laym2C3QQRLIO2TZCUNeU90x6Qw09LRxw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/schemes/-/schemes-1.4.0.tgz",
+      "integrity": "sha512-ImFy9FbCsQlVgnE3TCWmLPCFnVzx0lHL/l+umHplDqAKd0dzFpnS6lFZIpagBlYhKwzVmlV36ec0Y1XTu8JBAQ==",
       "dependencies": {
         "extend": "^3.0.0"
       }
@@ -1884,9 +1884,9 @@
       "dev": true
     },
     "schemes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/schemes/-/schemes-1.3.0.tgz",
-      "integrity": "sha512-j897hccQkOKrATAnSFfERCv07Wxw5ciXfQCxD0hUWG54nqSWcqv+6laym2C3QQRLIO2TZCUNeU90x6Qw09LRxw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/schemes/-/schemes-1.4.0.tgz",
+      "integrity": "sha512-ImFy9FbCsQlVgnE3TCWmLPCFnVzx0lHL/l+umHplDqAKd0dzFpnS6lFZIpagBlYhKwzVmlV36ec0Y1XTu8JBAQ==",
       "requires": {
         "extend": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/luzlab/ajv-formats-draft2019.git",
   "dependencies": {
     "punycode": "^2.1.1",
-    "schemes": "^1.3.0",
+    "schemes": "^1.4.0",
     "smtp-address-parser": "^1.0.3",
     "uri-js": "^4.4.1"
   },


### PR DESCRIPTION
Only changes were updating the `schemes` dependency to `~1.4.0` and adding unit tests for the new schemes.