### PR TITLE
Fix validation of URI with fragment as IRI

### DIFF
--- a/formats/iri.js
+++ b/formats/iri.js
@@ -16,7 +16,7 @@ module.exports = (value) => {
   if (iri.scheme === 'mailto' && iri.to.every(validate)) {
     return true;
   }
-  if (iri.reference === 'absolute' && schemes.allByName[iri.scheme]) {
+  if ((iri.reference === 'absolute' || iri.reference === 'uri') && schemes.allByName[iri.scheme]) {
     return true;
   }
   return false;

--- a/index.test.js
+++ b/index.test.js
@@ -45,6 +45,9 @@ describe('load types', function () {
     // https://github.com/luzlab/ajv-formats-draft2019/issues/11
     assert.ok(validate('modbus+tcp://1.2.3.4/path'));
     assert.ok(validate('mqtt://1.2.3.4/path'));
+
+    // https://github.com/luzlab/ajv-formats-draft2019/issues/16
+    assert.ok(validate('http://www.w3.org/2004/02/skos/core#Concept'));
   });
 
   it('reject invalid IRIs', function () {


### PR DESCRIPTION
Library uri-js marks absolute URIs as `uri` instead of `absolute` so
URIs with fragment identifier (possibly among other edge cases) were
wrongly marked as invalid. See test case as an example that failed.

Fixes <https://github.com/luzlab/ajv-formats-draft2019/issues/16>