### PR TITLE
fix iri scheme constriants

### DIFF
--- a/formats/ini-abnf.js
+++ b/formats/ini-abnf.js
@@ -1,0 +1,9 @@
+/**
+ * iri ABNF
+ * @see https://datatracker.ietf.org/doc/html/rfc3987#section-2.2
+ * @internal
+ */
+module.exports = Object.freeze({
+    scheme: /^[a-zA-Z0-9][a-zA-Z0-9.+-]+$/,
+})
+

--- a/formats/iri-reference.js
+++ b/formats/iri-reference.js
@@ -1,6 +1,6 @@
 const { parse } = require('uri-js');
 const addressParser = require('smtp-address-parser').parse;
-const schemes = require('schemes');
+const { scheme} = require('./ini-abnf')
 
 function validate(address) {
   try {
@@ -21,7 +21,7 @@ module.exports = (value) => {
   if (
     iri.reference === 'absolute' &&
     iri.path !== undefined &&
-    schemes.allByName[iri.scheme]
+    scheme.test(iri.scheme)
   ) {
     return true;
   }
@@ -29,7 +29,7 @@ module.exports = (value) => {
   // Check for valid IRI-reference
 
   // If there is a scheme, it must be valid
-  if (iri.scheme && !schemes.allByName[iri.scheme]) {
+  if (iri.scheme && !scheme.test(iri.scheme)) {
     return false;
   }
 

--- a/formats/iri.js
+++ b/formats/iri.js
@@ -1,6 +1,6 @@
 const { parse } = require('uri-js');
 const addressParser = require('smtp-address-parser').parse;
-const schemes = require('schemes');
+const { scheme} = require('./ini-abnf')
 
 function validate(address) {
   try {
@@ -16,7 +16,7 @@ module.exports = (value) => {
   if (iri.scheme === 'mailto' && iri.to.every(validate)) {
     return true;
   }
-  if ((iri.reference === 'absolute' || iri.reference === 'uri') && schemes.allByName[iri.scheme]) {
+  if ((iri.reference === 'absolute' || iri.reference === 'uri') && scheme.test(iri.scheme)) {
     return true;
   }
   return false;

--- a/index.test.js
+++ b/index.test.js
@@ -48,6 +48,10 @@ describe('load types', function () {
 
     // https://github.com/luzlab/ajv-formats-draft2019/issues/16
     assert.ok(validate('http://www.w3.org/2004/02/skos/core#Concept'));
+
+    // https://github.com/luzlab/ajv-formats-draft2019/issues/22
+    assert.ok(validate('git+https://github.com/Alex-D/check-disk-space.git'));
+    assert.ok(validate('git+ssh://git@github.com/estools/escodegen.git'));
   });
 
   it('reject invalid IRIs', function () {
@@ -60,8 +64,6 @@ describe('load types', function () {
     };
     var validate = ajv.compile(schema);
     assert.ok(!validate('example.com')); // missing a scheme
-    assert.ok(!validate('invalidScheme://example.com')); // an invalid scheme
-    assert.ok(!validate('this:that'));
 
     // These are IRI-References not IRI
     assert.ok(!validate('#someelement'));
@@ -292,9 +294,6 @@ describe('load types', function () {
       format: 'iri-reference',
     };
     var validate = ajv.compile(schema);
-
-    // https://tools.ietf.org/html/rfc3986#section-4.2
-    assert.ok(!validate('this:that'));
 
     // https://github.com/luzlab/ajv-formats-draft2019/issues/9
     assert.ok(!validate('mailto:invalid.format'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.1.1",
-        "schemes": "^1.4.0",
         "smtp-address-parser": "^1.0.3",
         "uri-js": "^4.4.1"
       },
@@ -360,11 +359,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -921,14 +915,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/schemes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/schemes/-/schemes-1.4.0.tgz",
-      "integrity": "sha512-ImFy9FbCsQlVgnE3TCWmLPCFnVzx0lHL/l+umHplDqAKd0dzFpnS6lFZIpagBlYhKwzVmlV36ec0Y1XTu8JBAQ==",
-      "dependencies": {
-        "extend": "^3.0.0"
-      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -1496,11 +1482,6 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1882,14 +1863,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
-    },
-    "schemes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/schemes/-/schemes-1.4.0.tgz",
-      "integrity": "sha512-ImFy9FbCsQlVgnE3TCWmLPCFnVzx0lHL/l+umHplDqAKd0dzFpnS6lFZIpagBlYhKwzVmlV36ec0Y1XTu8JBAQ==",
-      "requires": {
-        "extend": "^3.0.0"
-      }
     },
     "serialize-javascript": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "repository": "https://github.com/luzlab/ajv-formats-draft2019.git",
   "dependencies": {
     "punycode": "^2.1.1",
-    "schemes": "^1.4.0",
     "smtp-address-parser": "^1.0.3",
     "uri-js": "^4.4.1"
   },


### PR DESCRIPTION
fix scheme constaints according to https://datatracker.ietf.org/doc/html/rfc3987#section-2.2
```ABNF
   scheme         = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
```

there is no coins taint to a certain list of known, but a formal requirement.

fixes #22 
related to #11 