### PR TITLE
require non-obsolete version of punycode

### DIFF
--- a/formats/idn-hostname.js
+++ b/formats/idn-hostname.js
@@ -1,4 +1,4 @@
-const { toASCII } = require('punycode');
+const { toASCII } = require('punycode/');
 
 const hostnameRegex =
   /^(?=.{1,253}\.?$)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[-0-9a-z]{0,61}[0-9a-z])?)*\.?$/i;


### PR DESCRIPTION
Per the punycode readme at https://github.com/mathiasbynens/punycode.js, you must include a slash at the end of the import to get the non-deprecated implementation of punycode. Resolves issue 28 https://github.com/luzlab/ajv-formats-draft2019/issues/28 